### PR TITLE
Update non-TheiaProk TBProfiler to v6.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile adjusts tb-profiler's ref genome so we can feed it BAMs directly from myco
-FROM staphb/tbprofiler:6.6.2
+FROM staphb/tbprofiler:6.7.0
 RUN wget https://raw.githubusercontent.com/aofarrel/tb_profiler/main/ref/tb_ref.fa
 RUN samtools faidx tb_ref.fa
 RUN bwa index tb_ref.fa

--- a/tbprofiler_tasks.wdl
+++ b/tbprofiler_tasks.wdl
@@ -30,7 +30,7 @@ task tb_profiler_fastq {
     runtime {
         cpu: cpu
         disks: "local-disk " + diskSize + diskType
-        docker: "ashedpotatoes/tbprofiler:4.4.2"
+        docker: "ashedpotatoes/tbprofiler:6.7.0"
         memory: "${memory} GB"
         preemptible: "${preempt}"
     }
@@ -74,7 +74,7 @@ task tb_profiler_bam {
     runtime {
         cpu: cpu
         disks: "local-disk " + ceil(2*size(bam, "GB")) + diskType
-        docker: "ashedpotatoes/tbprofiler:4.4.2"
+        docker: "ashedpotatoes/tbprofiler:6.7.0"
         memory: "${memory} GB"
         preemptible: "${preempt}"
     }

--- a/tbprofiler_tasks.wdl
+++ b/tbprofiler_tasks.wdl
@@ -3,6 +3,7 @@ version 1.0
 task tb_profiler_fastq {
     input {
         Array[File] fastqs
+        Boolean legacy_docker = false
         
         Int addldisk = 15
         Int cpu = 2
@@ -30,7 +31,7 @@ task tb_profiler_fastq {
     runtime {
         cpu: cpu
         disks: "local-disk " + diskSize + diskType
-        docker: "ashedpotatoes/tbprofiler:6.7.0"
+        docker: if legacy_docker then "ashedpotatoes/tbprofiler:4.4.2" else "ashedpotatoes/tbprofiler:6.7.0"
         memory: "${memory} GB"
         preemptible: "${preempt}"
     }
@@ -54,6 +55,7 @@ task tb_profiler_bam {
     input {
         File bam
         String bam_suffix = "_to_H37Rv.bam"
+        Boolean legacy_docker = false
         
         Int cpu = 2
         Int memory = 4
@@ -74,7 +76,7 @@ task tb_profiler_bam {
     runtime {
         cpu: cpu
         disks: "local-disk " + ceil(2*size(bam, "GB")) + diskType
-        docker: "ashedpotatoes/tbprofiler:6.7.0"
+        docker: if legacy_docker then "ashedpotatoes/tbprofiler:4.4.2" else "ashedpotatoes/tbprofiler:6.7.0"
         memory: "${memory} GB"
         preemptible: "${preempt}"
     }


### PR DESCRIPTION
I have an ashedpotatoes/tbprofiler:6.2.1 Docker image, but the non-TheiaProk tasks on main still reference 4.4.2 for [myco](https://github.com/aofarrel/myco) reproducibility. myco has since been overhauled to include just_like_2024 mode, freeing us from having to keep everything exactly the same forever.